### PR TITLE
DBUpdater failure

### DIFF
--- a/Core.ApplicationServices/DriveReportService.cs
+++ b/Core.ApplicationServices/DriveReportService.cs
@@ -253,7 +253,7 @@ namespace Core.ApplicationServices
             //Fetch personal approver for the person (Person and Leader of the substitute is the same)
             var personalApprover =
                 _substituteRepository.AsQueryable()
-                    .SingleOrDefault(
+                    .FirstOrDefault(
                         s =>
                             s.PersonId != s.LeaderId && s.PersonId == person.Id &&
                             s.StartDateTimestamp < currentDateTimestamp && s.EndDateTimestamp > currentDateTimestamp);
@@ -263,7 +263,7 @@ namespace Core.ApplicationServices
             }
 
             //Find an org unit where the person is not the leader, and then find the leader of that org unit to attach to the drive report
-            var orgUnit = _orgUnitRepository.AsQueryable().SingleOrDefault(o => o.Id == empl.OrgUnitId);
+            var orgUnit = _orgUnitRepository.AsQueryable().FirstOrDefault(o => o.Id == empl.OrgUnitId);
             var leaderOfOrgUnit =
                 _employmentRepository.AsQueryable().FirstOrDefault(e => e.OrgUnit.Id == orgUnit.Id && e.IsLeader && e.StartDateTimestamp < currentDateTimestamp && (e.EndDateTimestamp > currentDateTimestamp || e.EndDateTimestamp == 0));
 
@@ -276,7 +276,7 @@ namespace Core.ApplicationServices
 
             while ((leaderOfOrgUnit == null && orgUnit.Level > 0) || (leaderOfOrgUnit != null && leaderOfOrgUnit.PersonId == person.Id))
             {
-                leaderOfOrgUnit = _employmentRepository.AsQueryable().SingleOrDefault(e => e.OrgUnit.Id == orgUnit.ParentId && e.IsLeader &&
+                leaderOfOrgUnit = _employmentRepository.AsQueryable().FirstOrDefault(e => e.OrgUnit.Id == orgUnit.ParentId && e.IsLeader &&
                                                                                             e.StartDateTimestamp < currentTimestamp &&
                                                                                             (e.EndDateTimestamp == 0 || e.EndDateTimestamp > currentTimestamp)); 
                 orgUnit = orgUnit.Parent;
@@ -304,7 +304,7 @@ namespace Core.ApplicationServices
             var loopHasFinished = false;
             while (!loopHasFinished)
             {
-                sub = _substituteRepository.AsQueryable().SingleOrDefault(s => s.OrgUnitId == orgToCheck.Id && s.PersonId == leader.Id && s.StartDateTimestamp < currentDateTimestamp && s.EndDateTimestamp > currentDateTimestamp && s.PersonId.Equals(s.LeaderId));
+                sub = _substituteRepository.AsQueryable().FirstOrDefault(s => s.OrgUnitId == orgToCheck.Id && s.PersonId == leader.Id && s.StartDateTimestamp < currentDateTimestamp && s.EndDateTimestamp > currentDateTimestamp && s.PersonId.Equals(s.LeaderId));
                 if (sub != null)
                 {
                     if(sub.Sub == null)
@@ -337,7 +337,7 @@ namespace Core.ApplicationServices
             var empl = _employmentRepository.AsQueryable().First(x => x.Id == driveReport.EmploymentId);
 
             //Find an org unit where the person is not the leader, and then find the leader of that org unit to attach to the drive report
-            var orgUnit = _orgUnitRepository.AsQueryable().SingleOrDefault(o => o.Id == empl.OrgUnitId);
+            var orgUnit = _orgUnitRepository.AsQueryable().FirstOrDefault(o => o.Id == empl.OrgUnitId);
             var leaderOfOrgUnit =
                 _employmentRepository.AsQueryable().FirstOrDefault(e => e.OrgUnit.Id == orgUnit.Id && e.IsLeader && e.StartDateTimestamp < currentDateTimestamp && (e.EndDateTimestamp > currentDateTimestamp || e.EndDateTimestamp == 0));
 
@@ -350,7 +350,7 @@ namespace Core.ApplicationServices
 
             while ((leaderOfOrgUnit == null && orgUnit.Level > 0) || (leaderOfOrgUnit != null && leaderOfOrgUnit.PersonId == person.Id))
             {
-                leaderOfOrgUnit = _employmentRepository.AsQueryable().SingleOrDefault(e => e.OrgUnit.Id == orgUnit.ParentId && e.IsLeader &&
+                leaderOfOrgUnit = _employmentRepository.AsQueryable().FirstOrDefault(e => e.OrgUnit.Id == orgUnit.ParentId && e.IsLeader &&
                                                                                             e.StartDateTimestamp < currentTimestamp &&
                                                                                             (e.EndDateTimestamp == 0 || e.EndDateTimestamp > currentTimestamp));
                 orgUnit = orgUnit.Parent;


### PR DESCRIPTION
DBUpdater fails with "Adding leaders to reports that have none":

Unhandled Exception: System.InvalidOperationException: Sequence contains
more than one element
at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)

The solution was to use "FirstOrDefault" in the
"GetActualLeaderForReport" method.